### PR TITLE
fix(ratelimit): decode Lua allow results without int64 panic

### DIFF
--- a/x/ratelimit/ratelimit.go
+++ b/x/ratelimit/ratelimit.go
@@ -93,28 +93,12 @@ func (l Limiter) AllowN(
 		return nil, err
 	}
 
-	values, _ = v.([]any)
-
-	retryAfter, err := strconv.ParseFloat(values[2].(string), 64)
-	if err != nil {
-		return nil, err
+	values, ok := v.([]any)
+	if !ok || len(values) < 4 {
+		return nil, fmt.Errorf("ratelimit: unexpected redis result %T", v)
 	}
 
-	resetAfter, err := strconv.ParseFloat(values[3].(string), 64)
-	if err != nil {
-		return nil, err
-	}
-
-	//nolint:forcetypeassert
-	res := &Result{
-		Limit:      limit,
-		Allowed:    int(values[0].(int64)),
-		Remaining:  int(values[1].(int64)),
-		RetryAfter: dur(retryAfter),
-		ResetAfter: dur(resetAfter),
-	}
-
-	return res, nil
+	return parseAllowResult(limit, values)
 }
 
 // AllowAtMost reports whether at most n events may happen at time now.
@@ -132,28 +116,74 @@ func (l Limiter) AllowAtMost(
 		return nil, err
 	}
 
-	values, _ = v.([]any)
-
-	retryAfter, err := strconv.ParseFloat(values[2].(string), 64)
-	if err != nil {
-		return nil, err
+	values, ok := v.([]any)
+	if !ok || len(values) < 4 {
+		return nil, fmt.Errorf("ratelimit: unexpected redis result %T", v)
 	}
 
-	resetAfter, err := strconv.ParseFloat(values[3].(string), 64)
+	return parseAllowResult(limit, values)
+}
+
+func parseAllowResult(limit Limit, values []any) (*Result, error) {
+	allowed, err := redisInt(values[0])
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("ratelimit allowed: %w", err)
+	}
+	remaining, err := redisInt(values[1])
+	if err != nil {
+		return nil, fmt.Errorf("ratelimit remaining: %w", err)
 	}
 
-	//nolint:forcetypeassert
-	res := &Result{
+	retryAfter, err := redisFloat(values[2])
+	if err != nil {
+		return nil, fmt.Errorf("ratelimit retry_after: %w", err)
+	}
+	resetAfter, err := redisFloat(values[3])
+	if err != nil {
+		return nil, fmt.Errorf("ratelimit reset_after: %w", err)
+	}
+
+	return &Result{
 		Limit:      limit,
-		Allowed:    int(values[0].(int64)),
-		Remaining:  int(values[1].(int64)),
+		Allowed:    allowed,
+		Remaining:  remaining,
 		RetryAfter: dur(retryAfter),
 		ResetAfter: dur(resetAfter),
-	}
+	}, nil
+}
 
-	return res, nil
+// redisInt converts Redis Lua numeric results. Whole numbers often arrive as
+// int64; allow_n.lua returns remaining as a float (division), which go-redis
+// surfaces as float64 — a hard int64 assert panics on every successful Allow.
+func redisInt(v any) (int, error) {
+	switch n := v.(type) {
+	case int64:
+		return int(n), nil
+	case int:
+		return n, nil
+	case float64:
+		return int(n), nil
+	case string:
+		i, err := strconv.Atoi(n)
+		return i, err
+	default:
+		return 0, fmt.Errorf("unsupported numeric type %T", v)
+	}
+}
+
+func redisFloat(v any) (float64, error) {
+	switch n := v.(type) {
+	case string:
+		return strconv.ParseFloat(n, 64)
+	case float64:
+		return n, nil
+	case int64:
+		return float64(n), nil
+	case int:
+		return float64(n), nil
+	default:
+		return 0, fmt.Errorf("unsupported float type %T", v)
+	}
 }
 
 // Reset gets a key and reset all limitations and previous usages

--- a/x/ratelimit/ratelimit_test.go
+++ b/x/ratelimit/ratelimit_test.go
@@ -1,6 +1,9 @@
 package ratelimit
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 func TestLimitHelpers(t *testing.T) {
 	limit := PerSecond(5)
@@ -19,5 +22,50 @@ func TestLimitHelpers(t *testing.T) {
 func TestDur(t *testing.T) {
 	if got := dur(-1); got != -1 {
 		t.Fatalf("dur(-1) = %v, want -1", got)
+	}
+}
+
+func TestRedisInt(t *testing.T) {
+	t.Parallel()
+
+	n, err := redisInt(int64(3))
+	if err != nil || n != 3 {
+		t.Fatalf("int64: got %d, %v", n, err)
+	}
+	n, err = redisInt(float64(9.7))
+	if err != nil || n != 9 {
+		t.Fatalf("float64: got %d, %v", n, err)
+	}
+	n, err = redisInt("4")
+	if err != nil || n != 4 {
+		t.Fatalf("string: got %d, %v", n, err)
+	}
+	if _, err := redisInt(true); err == nil {
+		t.Fatal("expected error for bool")
+	}
+}
+
+func TestParseAllowResult_FloatRemaining(t *testing.T) {
+	t.Parallel()
+
+	// Mirrors go-redis decoding of allow_n.lua on a successful allow:
+	// cost is int64, remaining is float64 from Lua division.
+	res, err := parseAllowResult(PerMinute(10), []any{
+		int64(1),
+		float64(9),
+		"-1",
+		"6.0",
+	})
+	if err != nil {
+		t.Fatalf("parseAllowResult: %v", err)
+	}
+	if res.Allowed != 1 || res.Remaining != 9 {
+		t.Fatalf("unexpected result: %+v", res)
+	}
+	if res.RetryAfter != dur(-1) {
+		t.Fatalf("RetryAfter = %v, want -1", res.RetryAfter)
+	}
+	if res.ResetAfter != 6*time.Second {
+		t.Fatalf("ResetAfter = %v, want 6s", res.ResetAfter)
 	}
 }


### PR DESCRIPTION
## Summary
- `allow_n.lua` returns `remaining` as a float (`diff / emission_interval`); go-redis decodes that as `float64`
- `AllowN` / `AllowAtMost` previously asserted `int64`, which panics on every successful allow
- Parse Redis Lua numerics via `redisInt` / `redisFloat` (int64, float64, string) and return a typed error instead of panicking

## Test plan
- [x] `go test ./...` in `x/ratelimit`
- [ ] After merge/tag, bump `github.com/clubpay/ronykit/x/ratelimit` in nested-agents bot and confirm Telegram inbound no longer crashes the server


Made with [Cursor](https://cursor.com)